### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.21'
+        cache: false
+
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.55.2
+  
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.21'
+        cache: false
+
+    - name: Test
+      uses: robherley/go-test-action@v0.1.0
+      with:
+        testArguments: './pkg/... -coverprofile=./cover.out'
+
+    - name: Check coverage
+      uses: vladopajic/go-test-coverage@v2
+      if: always()
+      with:
+        config: ./.testcoverage.yml

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,0 +1,10 @@
+profile: cover.out
+threshold:
+  file: 80
+  package: 80
+  total: 80
+
+exclude:
+  paths:
+    - ^pkg/internal
+    - ^pkg/config


### PR DESCRIPTION
# Description

Add CI workflow with two jobs:
* Lint
* Test

The **Lint** job executes **golangci-lint** with default rules

The **Test** job runs only tests located inside `./pkg`, generates a summary of successful and failed tests and evaluates code coverage