### PR TITLE
Fix quantity type

### DIFF
--- a/examples/apis/preapproval/search/main.go
+++ b/examples/apis/preapproval/search/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"github.com/mercadopago/sdk-go/pkg/config"
 	"github.com/mercadopago/sdk-go/pkg/preapproval"
 )
@@ -17,8 +18,8 @@ func main() {
 	client := preapproval.NewClient(cfg)
 
 	filters := preapproval.SearchRequest{
-		Limit:  "10",
-		Offset: "10",
+		Limit:  10,
+		Offset: 10,
 		Filters: map[string]string{
 			"payer_id": "123123123",
 		},

--- a/pkg/payment/response.go
+++ b/pkg/payment/response.go
@@ -103,7 +103,7 @@ type ItemResponse struct {
 	Description string  `json:"description"`
 	PictureURL  string  `json:"picture_url"`
 	CategoryID  string  `json:"category_id"`
-	Quantity    int     `json:"quantity"`
+	Quantity    string  `json:"quantity"`
 	UnitPrice   float64 `json:"unit_price"`
 }
 


### PR DESCRIPTION
The field quantity sent in payment.additional_info.items node can be string or int, but returns as a string.
This PR fixes it.
Reported in the following issue: https://github.com/mercadopago/sdk-go/issues/38.