### PR TITLE
Include sub_merchant

### DIFF
--- a/examples/apis/preference/create/main.go
+++ b/examples/apis/preference/create/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	cfg, err := config.New("APP_USR-3031066189562927-042217-7204e46c8ca7b09cee4327a6e38f8c0d-831921084")
+	cfg, err := config.New("{{ACCESS_TOKEN}}")
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -20,26 +20,9 @@ func main() {
 			{
 				ID:          "123",
 				Title:       "Title",
-				UnitPrice:   75,
+				UnitPrice:   100,
 				Quantity:    1,
 				Description: "Description",
-			},
-		},
-		PaymentMethods: &preference.PaymentMethodsRequest{
-			DefaultPaymentMethodID: "visa",
-		},
-		Payer: &preference.PayerRequest{
-			Name:    "tyuio",
-			Surname: "gfhjkl",
-			Email:   "test_user_61213998@testuser.com",
-			Identification: &preference.IdentificationRequest{
-				Type:   "CPF",
-				Number: "19119119100",
-			},
-			Address: &preference.AddressRequest{
-				ZipCode:      "88054000",
-				StreetName:   "Rua PREFERENCE",
-				StreetNumber: "12345",
 			},
 		},
 	}

--- a/examples/apis/preference/create/main.go
+++ b/examples/apis/preference/create/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	cfg, err := config.New("{{ACCESS_TOKEN}}")
+	cfg, err := config.New("APP_USR-3031066189562927-042217-7204e46c8ca7b09cee4327a6e38f8c0d-831921084")
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -20,9 +20,26 @@ func main() {
 			{
 				ID:          "123",
 				Title:       "Title",
-				UnitPrice:   100,
+				UnitPrice:   75,
 				Quantity:    1,
 				Description: "Description",
+			},
+		},
+		PaymentMethods: &preference.PaymentMethodsRequest{
+			DefaultPaymentMethodID: "visa",
+		},
+		Payer: &preference.PayerRequest{
+			Name:    "tyuio",
+			Surname: "gfhjkl",
+			Email:   "test_user_61213998@testuser.com",
+			Identification: &preference.IdentificationRequest{
+				Type:   "CPF",
+				Number: "19119119100",
+			},
+			Address: &preference.AddressRequest{
+				ZipCode:      "88054000",
+				StreetName:   "Rua PREFERENCE",
+				StreetNumber: "12345",
 			},
 		},
 	}

--- a/pkg/payment/request.go
+++ b/pkg/payment/request.go
@@ -188,7 +188,7 @@ type SubMerchantRequest struct {
 	SubMerchantId     string `json:"sub_merchant_id,omitempty"`
 	MCC               string `json:"mcc,omitempty"`
 	Country           string `json:"country,omitempty"`
-	AddressDoorNumber string `json:"address_door_number,omitempty"`
+	AddressDoorNumber int    `json:"address_door_number,omitempty"`
 	ZIP               string `json:"zip,omitempty"`
 	DocumentNumber    string `json:"document_number,omitempty"`
 	City              string `json:"city,omitempty"`

--- a/pkg/payment/request.go
+++ b/pkg/payment/request.go
@@ -10,6 +10,7 @@ type Request struct {
 	MerchantServices   *MerchantServicesRequest   `json:"merchant_services,omitempty"`
 	Order              *OrderRequest              `json:"order,omitempty"`
 	Payer              *PayerRequest              `json:"payer,omitempty"`
+	ForwardData        *ForwardDataRequest        `json:"forward_data,omitempty"`
 	TransactionDetails *TransactionDetailsRequest `json:"transaction_details,omitempty"`
 	PointOfInteraction *PointOfInteractionRequest `json:"point_of_interaction,omitempty"`
 	PaymentMethod      *PaymentMethodRequest      `json:"payment_method,omitempty"`
@@ -175,6 +176,29 @@ type PayerRequest struct {
 	FirstName  string `json:"first_name,omitempty"`
 	LastName   string `json:"last_name,omitempty"`
 	EntityType string `json:"entity_type,omitempty"`
+}
+
+// ForwardData represents data used in special conditions for the payment.
+type ForwardDataRequest struct {
+	SubMerchant *SubMerchantRequest `json:"sub_merchant,omitempty"`
+}
+
+// SubMerchantRequest represents sub merchant request within ForwardDataRequest.
+type SubMerchantRequest struct {
+	SubMerchantId     string `json:"sub_merchant_id,omitempty"`
+	MCC               string `json:"mcc,omitempty"`
+	Country           string `json:"country,omitempty"`
+	AddressDoorNumber string `json:"address_door_number,omitempty"`
+	ZIP               string `json:"zip,omitempty"`
+	DocumentNumber    string `json:"document_number,omitempty"`
+	City              string `json:"city,omitempty"`
+	AddressStreet     string `json:"address_street,omitempty"`
+	LegalName         string `json:"legal_name,omitempty"`
+	RegionCodeIso     string `json:"region_code_iso,omitempty"`
+	RegionCode        string `json:"region_code,omitempty"`
+	DocumentType      string `json:"document_type,omitempty"`
+	Phone             string `json:"phone,omitempty"`
+	URL               string `json:"url,omitempty"`
 }
 
 // AddressRequest represents payer address request within PayerRequest.

--- a/pkg/payment/response.go
+++ b/pkg/payment/response.go
@@ -7,6 +7,7 @@ import (
 // Response is the response from the Payments API.
 type Response struct {
 	Payer              PayerResponse              `json:"payer"`
+	ForwardData        ForwardDataResponse        `json:"forward_data,omitempty"`
 	AdditionalInfo     AdditionalInfoResponse     `json:"additional_info"`
 	Order              OrderResponse              `json:"order"`
 	TransactionDetails TransactionDetailsResponse `json:"transaction_details"`
@@ -79,6 +80,27 @@ type PayerResponse struct {
 	FirstName  string `json:"first_name"`
 	LastName   string `json:"last_name"`
 	EntityType string `json:"entity_type"`
+}
+
+type ForwardDataResponse struct {
+	SubMerchant SubMerchantResponse `json:"sub_merchant,omitempty"`
+}
+
+type SubMerchantResponse struct {
+	SubMerchantId     string `json:"sub_merchant_id,omitempty"`
+	MCC               string `json:"mcc,omitempty"`
+	Country           string `json:"country,omitempty"`
+	AddressDoorNumber string `json:"address_door_number,omitempty"`
+	ZIP               string `json:"zip,omitempty"`
+	DocumentNumber    string `json:"document_number,omitempty"`
+	City              string `json:"city,omitempty"`
+	AddressStreet     string `json:"address_street,omitempty"`
+	LegalName         string `json:"legal_name,omitempty"`
+	RegionCodeIso     string `json:"region_code_iso,omitempty"`
+	RegionCode        string `json:"region_code,omitempty"`
+	DocumentType      string `json:"document_type,omitempty"`
+	Phone             string `json:"phone,omitempty"`
+	URL               string `json:"url,omitempty"`
 }
 
 // IdentificationResponse represents payer's personal identification.


### PR DESCRIPTION
## Changes made to the feature:
 * To use the Payment Facilitator integration, it is necessary to update the forward_data.sub_merchant property for sending the necessary’s  fields.