### PR TITLE
fix: last_charged_amount is a number

### DIFF
--- a/pkg/preapproval/response.go
+++ b/pkg/preapproval/response.go
@@ -52,7 +52,7 @@ type FreeTrialResponse struct {
 // SummarizedResponse contains summary information about invoices and subscription charges.
 type SummarizedResponse struct {
 	LastChargedDate   time.Time `json:"last_charged_date"`
-	LastChargedAmount time.Time `json:"last_charged_amount"`
+	LastChargedAmount float64   `json:"last_charged_amount"`
 
 	Semaphore             string  `json:"semaphore"`
 	PendingChargeAmount   float64 `json:"pending_charge_amount"`


### PR DESCRIPTION
In the preapproval package, when trying to unmarshal the SummarizedResponse struct, it throws the error: "Time.UnmarshalJSON: input is not a JSON string". This is because the LastChargedAmount field is of type time.Time, when it should be a number.