### PR TITLE
Bump to 1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## VERSION 1.0.8
+
+Fix `LastChargedAmount` to float64 in `Response`
+
 ## VERSION 1.0.7
 
 Fix `CardID` to string in `Response` from the `pre-approval flow` 

--- a/pkg/internal/httpclient/helper.go
+++ b/pkg/internal/httpclient/helper.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	currentSDKVersion string = "1.0.7"
+	currentSDKVersion string = "1.0.8"
 	productID         string = "CNITR48HSRV0CRPT3NI0"
 )
 


### PR DESCRIPTION
Bump to version, include:

- Fix `LastChargedAmount` to float64 in `Response`