### PR TITLE
feature: added network_transaction_id related fields and header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## VERSION 1.4.0
+
+Include `network-transaction-id`
+
 ## VERSION 1.3.0
 
 Include Order Industry Data Fields and Example

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	CorporationID string
 	IntegratorID  string
 	PlatformID    string
+	ExpandNodes   string
 }
 
 // New returns a new Config.

--- a/pkg/config/config_options.go
+++ b/pkg/config/config_options.go
@@ -42,3 +42,11 @@ func WithPlatformID(p string) Option {
 		return nil
 	}
 }
+
+// WithExpandNodes send nodes to be expanded in the response.
+func WithExpandNodes(nodes string) Option {
+	return func(c *Config) error {
+		c.ExpandNodes = nodes
+		return nil
+	}
+}

--- a/pkg/internal/httpclient/helper.go
+++ b/pkg/internal/httpclient/helper.go
@@ -98,6 +98,9 @@ func setHeaders(req *http.Request, cfg *config.Config, requestData RequestData) 
 	if cfg.PlatformID != "" {
 		req.Header.Set("X-Platform-Id", cfg.PlatformID)
 	}
+	if cfg.ExpandNodes != "" {
+		req.Header.Set("X-Expand-Response-Nodes", cfg.ExpandNodes)
+	}
 }
 
 func setPathParams(req *http.Request, params map[string]string) error {

--- a/pkg/internal/httpclient/helper.go
+++ b/pkg/internal/httpclient/helper.go
@@ -99,7 +99,7 @@ func setHeaders(req *http.Request, cfg *config.Config, requestData RequestData) 
 		req.Header.Set("X-Platform-Id", cfg.PlatformID)
 	}
 	if cfg.ExpandNodes != "" {
-		req.Header.Set("X-Expand-Response-Nodes", cfg.ExpandNodes)
+		req.Header.Set("X-Expand-Responde-Nodes", cfg.ExpandNodes)
 	}
 }
 

--- a/pkg/internal/httpclient/helper.go
+++ b/pkg/internal/httpclient/helper.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	currentSDKVersion string = "1.3.0"
+	currentSDKVersion string = "1.4.0"
 	productID         string = "CNITR48HSRV0CRPT3NI0"
 )
 

--- a/pkg/payment/request.go
+++ b/pkg/payment/request.go
@@ -195,7 +195,11 @@ type PayerRequest struct {
 
 // ForwardData represents data used in special conditions for the payment.
 type ForwardDataRequest struct {
-	SubMerchant *SubMerchantRequest `json:"sub_merchant,omitempty"`
+	SubMerchant            *SubMerchantRequest            `json:"sub_merchant,omitempty"`
+	NetworkTransactionData *NetworkTransactionDataRequest `json:"network_transaction_data,omitempty"`
+}
+type NetworkTransactionDataRequest struct {
+	NetworkTransactionID string `json:"network_transaction_id,omitempty"`
 }
 
 // SubMerchantRequest represents sub merchant request within ForwardDataRequest.

--- a/pkg/payment/response.go
+++ b/pkg/payment/response.go
@@ -16,6 +16,7 @@ type Response struct {
 	PaymentMethod      PaymentMethodResponse      `json:"payment_method"`
 	ThreeDSInfo        ThreeDSInfoResponse        `json:"three_ds_info"`
 	BackURLs           BackURLsResponse           `json:"back_urls,omitempty"`
+	Expanded           *ExpandedResponse          `json:"expanded,omitempty"`
 	DateCreated        time.Time                  `json:"date_created"`
 	DateApproved       time.Time                  `json:"date_approved"`
 	DateLastUpdated    time.Time                  `json:"date_last_updated"`
@@ -416,4 +417,14 @@ type BackURLsResponse struct {
 	Success string `json:"success,omitempty"`
 	Pending string `json:"pending,omitempty"`
 	Failure string `json:"failure,omitempty"`
+}
+
+type ExpandedResponse struct {
+	Gateway *GatewayResponse `json:"gateway,omitempty"`
+}
+type GatewayResponse struct {
+	Reference *ReferenceResponse `json:"reference,omitempty"`
+}
+type ReferenceResponse struct {
+	NetworkTransactionID string `json:"network_transaction_id,omitempty"`
 }


### PR DESCRIPTION
Adding network_transaction_id related fields to payments request and response. [Documentation](https://www.mercadopago.com.br/developers/pt/docs/automatic-payments/recurring-charges/network-transaction-id)
Request:
```
forward_data: {
     network_transaction_data: {
       network_transaction_id: "xxxxxxx"
     }
   }
```
Response:

```
"expanded": {
   "gateway": {
 	  "reference": {
 		 "network_transaction_id": "xxxxx"
 	    }
    }
}
```