### PR TITLE
[FIX] Store_ID type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## VERSION 1.4.1
+
+Fix `store_id` in `DeviceResponse` to accept string values.
+
 ## VERSION 1.4.0
 
 Include `network-transaction-id`

--- a/pkg/internal/httpclient/helper.go
+++ b/pkg/internal/httpclient/helper.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	currentSDKVersion string = "1.4.0"
+	currentSDKVersion string = "1.4.1"
 	productID         string = "CNITR48HSRV0CRPT3NI0"
 )
 

--- a/pkg/point/client_test.go
+++ b/pkg/point/client_test.go
@@ -363,7 +363,7 @@ func TestListDevices(t *testing.T) {
 					{
 						ID:            "PAX_A910__SMARTPOS1234345545",
 						PosID:         47792476,
-						StoreID:       47792478,
+						StoreID:       "47792478",
 						ExternalPosID: "SUC0101POS",
 						OperatingMode: "PDV",
 					},

--- a/pkg/point/response.go
+++ b/pkg/point/response.go
@@ -40,7 +40,7 @@ type DeviceResponse struct {
 	ExternalPosID string `json:"external_pos_id"`
 	OperatingMode string `json:"operating_mode"`
 	PosID         int    `json:"pos_id"`
-	StoreID       int    `json:"store_id"`
+	StoreID       string `json:"store_id"`
 }
 
 type PagingResponse struct {


### PR DESCRIPTION
Fix store_id in DeviceResponse to accept string values for compatibility with [Point API.](https://www.mercadopago.com.br/developers/pt/reference/integrations_api/_point_integration-api_devices/get)
