### PR TITLE
Fix wrong zipcode name

### DIFF
--- a/pkg/order/request.go
+++ b/pkg/order/request.go
@@ -78,7 +78,7 @@ type TravelRouterRequest struct {
 	Company           string `json:"company,omitempty"`
 }
 type PayerAddressRequest struct {
-	Zipcode      string `json:"zipcode,omitempty"`
+	ZipCode      string `json:"zip_code,omitempty"`
 	StreetName   string `json:"street_name,omitempty"`
 	StreetNumber string `json:"street_number,omitempty"`
 	Neighborhood string `json:"neighborhood,omitempty"`


### PR DESCRIPTION
According to [Mercado Pago documentation](https://www.mercadopago.com.br/developers/pt/reference/orders/online-payments/create/post) of creation of Order, the ZipCode field of PayerAddressRequest needs to be snake_case and actually is not separated.

Actual field is causing this errors:

```json
{"code":"required_properties","message":"Missing properties","details":["'$.payer.address' - missing properties: 'zip_code'"]},{"code":"unsupported_properties","message":"Properties not supported","details":["'$.payer.address' - additionalProperties 'zipcode' not allowed"]}]}
```