### PR TITLE
chore(release): bump SDK to 1.8.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## VERSION 1.8.0
+
+- Bump SDK version to 1.8.0
+
 ## VERSION 1.2.0
 
 Include Industry Data Fields and Example

--- a/pkg/internal/httpclient/helper.go
+++ b/pkg/internal/httpclient/helper.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	currentSDKVersion string = "1.2.0"
+	currentSDKVersion string = "1.8.0"
 	productID         string = "CNITR48HSRV0CRPT3NI0"
 )
 


### PR DESCRIPTION
### Descrição
- Atualiza a versão do SDK para 1.8.0.
- Atualiza o CHANGELOG correspondente.
- Sem outras alterações funcionais.

### Arquivos alterados
- `pkg/internal/httpclient/helper.go`: bump de `currentSDKVersion` para `1.8.0`
- `CHANGELOG.md`: entrada da versão 1.8.0

### Pós-merge
- Criar tag `v1.8.0` e publicar release (se aplicável).