### PR TITLE
Add PSE (Colombia) support to Orders

### DIFF
--- a/examples/apis/order/createpse/main.go
+++ b/examples/apis/order/createpse/main.go
@@ -1,0 +1,94 @@
+// Package main shows how to create an Order using PSE (Pagos Seguros en Línea — Colombia).
+//
+// PSE is Colombia's standard online bank-transfer payment method. The integrator
+// initiates the transaction with PaymentMethod.ID = "pse" and Type = "bank_transfer",
+// and must specify the buyer's bank via FinancialInstitution.
+//
+// Required PSE-specific fields:
+//   - PaymentMethod.ID = "pse" (fixed)
+//   - PaymentMethod.Type = "bank_transfer" (fixed)
+//   - PaymentMethod.FinancialInstitution = PSE bank code (see table below)
+//   - Currency = "COP" (Colombia only)
+//   - Payer.EntityType = "individual" or "association"
+//   - Payer.Identification.Type = "CC", "NIT", etc. (Colombian doc type)
+//   - AdditionalInfo.PayerIPAddress (required by the risk engine)
+//   - Config.Online.CallbackURL (URL the bank redirects to after authorization)
+//
+// Most-used PSE bank codes (full catalog via MP API):
+//
+//	Bancolombia ........... 1007
+//	Davivienda ............ 1051
+//	Banco de Bogotá ....... 1001
+//	BBVA Colombia ......... 1013
+//	Banco Popular ......... 1002
+//	Scotiabank Colpatria .. 1019
+//
+// Reference: https://www.mercadopago.com.co/developers/es/docs
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mercadopago/sdk-go/pkg/config"
+	"github.com/mercadopago/sdk-go/pkg/order"
+)
+
+func main() {
+	accessToken := "{{ACCESS_TOKEN}}"
+	c, err := config.New(accessToken)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	client := order.NewClient(c)
+	request := order.Request{
+		Type:              "online",
+		ProcessingMode:    "automatic",
+		TotalAmount:       "50000.00",
+		Currency:          "COP",
+		ExternalReference: "ref_pse_12345",
+		Transactions: &order.TransactionRequest{
+			Payments: []order.PaymentRequest{
+				{
+					Amount: "50000.00",
+					PaymentMethod: &order.PaymentMethodRequest{
+						ID:                   "pse",
+						Type:                 "bank_transfer",
+						FinancialInstitution: "1007", // Bancolombia
+					},
+				},
+			},
+		},
+		// Payer: entity_type + Colombian identification (CC/NIT) required for PSE.
+		Payer: &order.PayerRequest{
+			Email:      "{{PAYER_EMAIL}}",
+			FirstName:  "{{FIRST_NAME}}",
+			LastName:   "{{LAST_NAME}}",
+			EntityType: "individual",
+			Identification: &order.IdentificationRequest{
+				Type:   "CC",
+				Number: "{{PAYER_DOC_NUMBER}}",
+			},
+		},
+		// additional_info.payer.ip_address — required by MP's risk engine for PSE.
+		AdditionalInfo: &order.AdditionalInfoRequest{
+			PayerIPAddress: "{{CLIENT_IP}}",
+		},
+		// callback_url — where the bank redirects the buyer after authorization.
+		Config: &order.ConfigRequest{
+			Online: &order.OnlineConfigRequest{
+				CallbackURL: "{{CALLBACK_URL}}",
+			},
+		},
+	}
+
+	resource, err := client.Create(context.Background(), request)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println(resource)
+}

--- a/pkg/order/request.go
+++ b/pkg/order/request.go
@@ -45,6 +45,7 @@ type AdditionalInfoRequest struct {
 	PayerIsPrimeUser                   bool                      `json:"payer.is_prime_user,omitempty"`
 	PayerIsFirstPurchaseOnLine         bool                      `json:"payer.is_first_purchase_online,omitempty"`
 	PayerLastPurchase                  string                    `json:"payer.last_purchase,omitempty"`
+	PayerIPAddress                     string                    `json:"payer.ip_address,omitempty"`
 	ShipmentExpress                    bool                      `json:"shipment.express,omitempty"`
 	ShipmentLocalPickup                bool                      `json:"shipment.local_pickup,omitempty"`
 	PlatFormShipmentDeliveryPromise    string                    `json:"platform.shipment.delivery_promise,omitempty"`
@@ -113,11 +114,12 @@ type PaymentRequest struct {
 }
 
 type PaymentMethodRequest struct {
-	ID                  string `json:"id,omitempty"`
-	Type                string `json:"type,omitempty"`
-	Token               string `json:"token,omitempty"`
-	StatementDescriptor string `json:"statement_descriptor,omitempty"`
-	Installments        int    `json:"installments,omitempty"`
+	ID                   string `json:"id,omitempty"`
+	Type                 string `json:"type,omitempty"`
+	Token                string `json:"token,omitempty"`
+	StatementDescriptor  string `json:"statement_descriptor,omitempty"`
+	Installments         int    `json:"installments,omitempty"`
+	FinancialInstitution string `json:"financial_institution,omitempty"`
 }
 
 type AutomaticPaymentsRequest struct {


### PR DESCRIPTION
## Summary
Adds PSE (Pagos Seguros en Línea) support to the Order client so integrators in Colombia can initiate bank-transfer payments using the typed structs.

## Changes
- `PaymentMethodRequest`: add `FinancialInstitution` field
- `AdditionalInfoRequest`: add `PayerIPAddress` field with `payer.ip_address` JSON tag
- New example `examples/apis/order/createpse/main.go` with PSE bank codes and inline documentation

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/order/...` passes
- [ ] CI green