### PR TITLE
Add WebhookSignatureValidator utility

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,0 +1,265 @@
+// Package webhook provides utilities to verify the authenticity of incoming
+// MercadoPago webhook notifications.
+//
+// The package exposes a single entry point, [ValidateSignature], that
+// recomputes the HMAC-SHA256 signature locally and compares it in constant
+// time against the value carried in the x-signature header. The package
+// is stateless, performs no outbound HTTP calls, and does not depend on
+// any other SDK configuration; the integrator passes the secret signature
+// explicitly on every call.
+//
+// QR Code notifications are not signed by MercadoPago — do not call this
+// validator for those events; they will always fail signature verification.
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Reason enumerates why [ValidateSignature] may reject a notification.
+// Integrators are encouraged to log this value alongside the x-request-id
+// for correlation against the MercadoPago notifications dashboard.
+type Reason string
+
+const (
+	// ReasonMissingSignatureHeader: the x-signature header was missing, empty, or whitespace.
+	ReasonMissingSignatureHeader Reason = "MissingSignatureHeader"
+
+	// ReasonMalformedSignatureHeader: the header did not match the expected
+	// ts=...,vN=... format and could not be parsed.
+	ReasonMalformedSignatureHeader Reason = "MalformedSignatureHeader"
+
+	// ReasonMissingTimestamp: the header parsed correctly but no ts= component was present.
+	ReasonMissingTimestamp Reason = "MissingTimestamp"
+
+	// ReasonMissingHash: no hash was found in the header for any of the supported versions.
+	// Typically indicates MercadoPago has migrated to a new signature version and the
+	// SDK needs to be upgraded.
+	ReasonMissingHash Reason = "MissingHash"
+
+	// ReasonSignatureMismatch: the computed HMAC did not match the value in the header.
+	// Most often caused by an incorrect secret signature or a forged request.
+	ReasonSignatureMismatch Reason = "SignatureMismatch"
+
+	// ReasonTimestampOutOfTolerance: the header timestamp fell outside the configured
+	// tolerance window against the current clock.
+	ReasonTimestampOutOfTolerance Reason = "TimestampOutOfTolerance"
+)
+
+// SignatureError represents a webhook signature verification failure.
+// Detect it with [errors.As]:
+//
+//	var sigErr *webhook.SignatureError
+//	if errors.As(err, &sigErr) {
+//	    log.Warn().Str("reason", string(sigErr.Reason)).Msg("rejected")
+//	    w.WriteHeader(http.StatusUnauthorized)
+//	}
+type SignatureError struct {
+	// Reason describes the specific failure mode.
+	Reason Reason
+
+	// RequestID echoes the x-request-id header value, when available.
+	RequestID string
+
+	// Timestamp echoes the ts value extracted from the x-signature header,
+	// when parsing reached that point.
+	Timestamp string
+}
+
+// Error implements the error interface.
+func (e *SignatureError) Error() string {
+	return fmt.Sprintf("webhook: invalid signature: %s", e.Reason)
+}
+
+// Option configures the behaviour of [ValidateSignature]. Following the
+// functional-options pattern used elsewhere in this SDK (see pkg/config),
+// each Option returns an error to allow validation of the supplied value.
+type Option func(*options) error
+
+type options struct {
+	tolerance         time.Duration
+	toleranceSet      bool
+	supportedVersions []string
+	now               func() time.Time
+}
+
+// WithTolerance enables the timestamp drift check with the given window.
+// When omitted, no timestamp check is performed.
+func WithTolerance(d time.Duration) Option {
+	return func(o *options) error {
+		if d < 0 {
+			return fmt.Errorf("tolerance must be non-negative, got %s", d)
+		}
+		o.tolerance = d
+		o.toleranceSet = true
+		return nil
+	}
+}
+
+// WithSupportedVersions overrides the default list of signature versions
+// the validator will accept (default: []string{"v1"}). The validator
+// iterates in order and uses the first version found in the header.
+func WithSupportedVersions(versions ...string) Option {
+	return func(o *options) error {
+		if len(versions) == 0 {
+			return fmt.Errorf("supportedVersions must not be empty")
+		}
+		o.supportedVersions = versions
+		return nil
+	}
+}
+
+// WithNow overrides the clock used for the tolerance check. Intended for tests.
+func WithNow(now func() time.Time) Option {
+	return func(o *options) error {
+		if now == nil {
+			return fmt.Errorf("now must not be nil")
+		}
+		o.now = now
+		return nil
+	}
+}
+
+var (
+	defaultSupportedVersions = []string{"v1"}
+	versionKeyRegex          = regexp.MustCompile(`^v\d+$`)
+)
+
+// ValidateSignature verifies a MercadoPago webhook notification.
+//
+// Inputs:
+//
+//   - xSignature: raw value of the x-signature header (e.g. "ts=...,v1=...").
+//   - xRequestID: raw value of the x-request-id header. May be empty; in that
+//     case the request-id: pair is omitted from the manifest.
+//   - dataID: value of the data.id query parameter. May be empty; in that
+//     case the id: pair is omitted. When present, it is lowercased before
+//     being included in the manifest.
+//   - secret: the secret signature configured for the application in
+//     Tus Integraciones. Used as the HMAC key.
+//
+// On failure it returns a non-nil error that wraps [ErrInvalidSignature];
+// use [errors.As] with [*SignatureError] to inspect the specific [Reason],
+// [SignatureError.RequestID], and [SignatureError.Timestamp].
+//
+// The comparison is performed in constant time via [hmac.Equal] to mitigate
+// timing attacks.
+func ValidateSignature(xSignature, xRequestID, dataID, secret string, opts ...Option) error {
+	o := &options{}
+	for _, opt := range opts {
+		if err := opt(o); err != nil {
+			return fmt.Errorf("webhook: invalid option: %w", err)
+		}
+	}
+	if len(o.supportedVersions) == 0 {
+		o.supportedVersions = defaultSupportedVersions
+	}
+	if o.now == nil {
+		o.now = time.Now
+	}
+
+	xSignature = normalize(xSignature)
+	xRequestID = normalize(xRequestID)
+	dataID = normalize(dataID)
+
+	if xSignature == "" {
+		return &SignatureError{Reason: ReasonMissingSignatureHeader, RequestID: xRequestID}
+	}
+
+	ts, hashes := parseSignatureHeader(xSignature)
+
+	if ts == "" && len(hashes) == 0 {
+		return &SignatureError{Reason: ReasonMalformedSignatureHeader, RequestID: xRequestID}
+	}
+
+	if ts == "" {
+		return &SignatureError{Reason: ReasonMissingTimestamp, RequestID: xRequestID}
+	}
+
+	tsMs, parseErr := strconv.ParseInt(ts, 10, 64)
+	if parseErr != nil {
+		return &SignatureError{Reason: ReasonMalformedSignatureHeader, RequestID: xRequestID, Timestamp: ts}
+	}
+
+	var receivedHash string
+	for _, v := range o.supportedVersions {
+		if h, ok := hashes[v]; ok {
+			receivedHash = h
+			break
+		}
+	}
+
+	if receivedHash == "" {
+		return &SignatureError{Reason: ReasonMissingHash, RequestID: xRequestID, Timestamp: ts}
+	}
+
+	manifest := buildManifest(dataID, xRequestID, ts)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(manifest))
+	computed := hex.EncodeToString(mac.Sum(nil))
+
+	if !hmac.Equal([]byte(computed), []byte(receivedHash)) {
+		return &SignatureError{Reason: ReasonSignatureMismatch, RequestID: xRequestID, Timestamp: ts}
+	}
+
+	if o.toleranceSet {
+		nowMs := o.now().UnixMilli()
+		drift := nowMs - tsMs
+		if drift < 0 {
+			drift = -drift
+		}
+		if drift > o.tolerance.Milliseconds() {
+			return &SignatureError{Reason: ReasonTimestampOutOfTolerance, RequestID: xRequestID, Timestamp: ts}
+		}
+	}
+
+	return nil
+}
+
+// normalize trims whitespace and treats empty values as missing.
+func normalize(s string) string {
+	return strings.TrimSpace(s)
+}
+
+// parseSignatureHeader extracts the ts and vN components from the x-signature header.
+// Unknown keys are silently ignored.
+func parseSignatureHeader(header string) (ts string, hashes map[string]string) {
+	hashes = map[string]string{}
+	for _, part := range strings.Split(header, ",") {
+		rawKey, rawValue, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(rawKey))
+		value := strings.TrimSpace(rawValue)
+		if key == "" || value == "" {
+			continue
+		}
+		if key == "ts" {
+			ts = value
+		} else if versionKeyRegex.MatchString(key) {
+			hashes[key] = value
+		}
+	}
+	return ts, hashes
+}
+
+// buildManifest assembles the HMAC manifest, omitting pairs whose value is empty.
+func buildManifest(dataID, requestID, ts string) string {
+	parts := make([]string, 0, 3)
+	if dataID != "" {
+		parts = append(parts, "id:"+strings.ToLower(dataID))
+	}
+	if requestID != "" {
+		parts = append(parts, "request-id:"+requestID)
+	}
+	parts = append(parts, "ts:"+ts)
+	return strings.Join(parts, ";") + ";"
+}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1,0 +1,183 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	secret       = "your_secret_key_here"
+	requestID    = "2066ca19-c6f1-498a-be75-1923005edd06"
+	dataIDRaw    = "ORD01JQ4S4KY8HWQ6NA5PXB65B3D3"
+	dataIDLower  = "ord01jq4s4ky8hwq6na5pxb65b3d3"
+	ts           = "1742505638683"
+	tsNum  int64 = 1742505638683
+)
+
+func computeHash(dataID, requestID, ts, secret string) string {
+	var parts []string
+	if dataID != "" {
+		parts = append(parts, "id:"+strings.ToLower(dataID))
+	}
+	if requestID != "" {
+		parts = append(parts, "request-id:"+requestID)
+	}
+	parts = append(parts, "ts:"+ts)
+	manifest := strings.Join(parts, ";") + ";"
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(manifest))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func buildHeader(hash string, optTs ...string) string {
+	t := ts
+	if len(optTs) > 0 {
+		t = optTs[0]
+	}
+	return "ts=" + t + ",v1=" + hash
+}
+
+func expectReason(t *testing.T, err error, want Reason) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var sigErr *SignatureError
+	if !errors.As(err, &sigErr) {
+		t.Fatalf("expected *SignatureError, got %T", err)
+	}
+	if sigErr.Reason != want {
+		t.Errorf("Reason: got %q, want %q", sigErr.Reason, want)
+	}
+}
+
+// case 1
+func TestValidateSignature_HappyPathLowercase(t *testing.T) {
+	h := computeHash(dataIDLower, requestID, ts, secret)
+	if err := ValidateSignature(buildHeader(h), requestID, dataIDLower, secret); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// case 2
+func TestValidateSignature_UppercaseDataIDIsLowercased(t *testing.T) {
+	h := computeHash(dataIDLower, requestID, ts, secret)
+	if err := ValidateSignature(buildHeader(h), requestID, dataIDRaw, secret); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// case 3
+func TestValidateSignature_MalformedHeader(t *testing.T) {
+	err := ValidateSignature("this-is-garbage", requestID, dataIDLower, secret)
+	expectReason(t, err, ReasonMalformedSignatureHeader)
+}
+
+// case 4
+func TestValidateSignature_MissingHeader(t *testing.T) {
+	err := ValidateSignature("", requestID, dataIDLower, secret)
+	expectReason(t, err, ReasonMissingSignatureHeader)
+}
+
+// case 5
+func TestValidateSignature_MissingTimestamp(t *testing.T) {
+	h := computeHash(dataIDLower, requestID, ts, secret)
+	err := ValidateSignature("v1="+h, requestID, dataIDLower, secret)
+	expectReason(t, err, ReasonMissingTimestamp)
+}
+
+// case 6
+func TestValidateSignature_MissingV1(t *testing.T) {
+	err := ValidateSignature("ts="+ts, requestID, dataIDLower, secret)
+	expectReason(t, err, ReasonMissingHash)
+}
+
+// case 7
+func TestValidateSignature_TamperedHash(t *testing.T) {
+	h := computeHash(dataIDLower, requestID, ts, secret)
+	tampered := h[:len(h)-2] + "00"
+	if strings.HasSuffix(h, "00") {
+		tampered = h[:len(h)-2] + "ff"
+	}
+	err := ValidateSignature(buildHeader(tampered), requestID, dataIDLower, secret)
+	expectReason(t, err, ReasonSignatureMismatch)
+}
+
+// case 8
+func TestValidateSignature_OutsideTolerance(t *testing.T) {
+	h := computeHash(dataIDLower, requestID, ts, secret)
+	far := func() time.Time { return time.UnixMilli(tsNum + 10*60*1000) }
+	err := ValidateSignature(buildHeader(h), requestID, dataIDLower, secret,
+		WithTolerance(60*time.Second), WithNow(far))
+	expectReason(t, err, ReasonTimestampOutOfTolerance)
+}
+
+func TestValidateSignature_WithinTolerance(t *testing.T) {
+	h := computeHash(dataIDLower, requestID, ts, secret)
+	near := func() time.Time { return time.UnixMilli(tsNum + 30*1000) }
+	if err := ValidateSignature(buildHeader(h), requestID, dataIDLower, secret,
+		WithTolerance(60*time.Second), WithNow(near)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// case 9
+func TestValidateSignature_DataIDAbsent(t *testing.T) {
+	h := computeHash("", requestID, ts, secret)
+	if err := ValidateSignature(buildHeader(h), requestID, "", secret); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// case 10
+func TestValidateSignature_RequestIDAbsent(t *testing.T) {
+	h := computeHash(dataIDLower, "", ts, secret)
+	if err := ValidateSignature(buildHeader(h), "", dataIDLower, secret); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// case 11
+func TestValidateSignature_BothAbsent(t *testing.T) {
+	h := computeHash("", "", ts, secret)
+	if err := ValidateSignature(buildHeader(h), "  ", "", secret); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// case 12
+func TestValidateSignature_NonPaymentTopic(t *testing.T) {
+	orderID := "ord01abc123"
+	h := computeHash(orderID, requestID, ts, secret)
+	if err := ValidateSignature(buildHeader(h), requestID, orderID, secret); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// supportedVersions
+func TestValidateSignature_SupportsV1WhenBothPresent(t *testing.T) {
+	h := computeHash(dataIDLower, requestID, ts, secret)
+	header := "ts=" + ts + ",v1=" + h + ",v2=aaaa"
+	if err := ValidateSignature(header, requestID, dataIDLower, secret); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateSignature_OnlyV2InHeaderOnlyV1Supported(t *testing.T) {
+	header := "ts=" + ts + ",v2=somehash"
+	err := ValidateSignature(header, requestID, dataIDLower, secret)
+	expectReason(t, err, ReasonMissingHash)
+}
+
+func TestValidateSignature_ErrorsAsSignatureError(t *testing.T) {
+	err := ValidateSignature("garbage", requestID, dataIDLower, secret)
+	var sigErr *SignatureError
+	if !errors.As(err, &sigErr) {
+		t.Errorf("expected errors.As(err, &SignatureError) == true, got false")
+	}
+}


### PR DESCRIPTION
## Summary
Adds a stateless utility to verify the authenticity of incoming MercadoPago webhook notifications by recomputing the HMAC-SHA256 signature and comparing it against the `x-signature` header in constant time (timing-attack safe).

## Changes
- `pkg/webhook/webhook.go`: HMAC-SHA256 validator with explicit secret per call, typed failure reasons
- `pkg/webhook/webhook_test.go`: unit tests covering success, malformed inputs, timestamp window, hash mismatch

## Test plan
- [ ] CI green