### PR TITLE
Bump Go toolchain to 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.23'
         cache: false
 
     - name: Run golangci-lint
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.23'
         cache: false
 
     - name: Test

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A comprehensive Go client library for integrating with the Mercado Pago API.
 
 ## 💡 Requirements
 
-The SDK requires Go 1.18 or higher.
+The SDK requires Go 1.23 or higher.
 
 ## 📲 Installation
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/mercadopago/sdk-go
 
-go 1.18.0
+go 1.23.0
 
 require github.com/google/uuid v1.5.0


### PR DESCRIPTION
## Summary
Bumps the `go` directive in `go.mod` from 1.18 to 1.23 to drop EOL Go versions and align with current supported toolchains in CI.

## Changes
- `go.mod`: bump `go` directive 1.18 → 1.23 **(breaking — consumers must build with Go 1.23+)**
- `.github/workflows/ci.yml`: update CI matrix to match

## Test plan
- [ ] CI green