### PR TITLE
chore: add Dependabot version updates and dependency audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+# Dependabot version updates — sdk-go
+# Ubicación obligatoria: .github/dependabot.yml
+# Ecosistemas: gomod (Go modules) + github-actions
+version: 2
+
+updates:
+  # ── Go modules ───────────────────────────────────────────────────────
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Bogota"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "mercadopago/backend-sdks"
+    assignees:
+      - "mercadopago/backend-sdks"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # ── GitHub Actions (CI) ──────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Bogota"
+    open-pull-requests-limit: 1
+    reviewers:
+      - "mercadopago/backend-sdks"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
       time: "09:00"
       timezone: "America/Bogota"
     open-pull-requests-limit: 5
-    reviewers:
-      - "mercadopago/backend-sdks"
     assignees:
       - "mercadopago/backend-sdks"
     labels:
@@ -35,8 +33,6 @@ updates:
       time: "09:00"
       timezone: "America/Bogota"
     open-pull-requests-limit: 1
-    reviewers:
-      - "mercadopago/backend-sdks"
     labels:
       - "dependencies"
       - "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,9 @@ jobs:
       if: always()
       with:
         config: ./.testcoverage.yml
+
+    - name: Install govulncheck
+      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+    - name: Dependency audit
+      run: govulncheck ./...


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` to enable proactive dependency updates (Go modules + GitHub Actions), weekly on Mondays at 09:00 America/Bogota, assigned to `mercadopago/backend-sdks`, ignoring semver-major bumps
- Add dependency audit step to CI (`govulncheck ./...`) to close the Dependabot loop: PR opened → CI runs → audit confirms CVE resolved → merge

## Test plan

- [ ] Verify `.github/dependabot.yml` is valid (GitHub will show a check in Security → Dependabot after merge)
- [ ] Enable **Dependabot version updates** in Settings → Security & analysis
- [ ] Confirm CI audit step runs on next PR