### PR TITLE
feat(order): add missing AP fields to order request models (IXE-679)

### DIFF
--- a/pkg/order/request.go
+++ b/pkg/order/request.go
@@ -26,6 +26,9 @@ type Request struct {
 	Config              *ConfigRequest         `json:"config,omitempty"`
 	Shipment            *ShipmentRequest       `json:"shipment,omitempty"`
 	AdditionalInfo      *AdditionalInfoRequest `json:"additional_info,omitempty"`
+	// IntegrationData contains integration metadata identifying the integrator, platform,
+	// corporation, and sponsor.
+	IntegrationData *IntegrationDataRequest `json:"integration_data,omitempty"`
 }
 
 // TravelPassengerRequest represents a passenger in a travel-related order.
@@ -130,6 +133,7 @@ type TransactionRequest struct {
 type PaymentRequest struct {
 	Amount            string                    `json:"amount,omitempty"`
 	ExpirationTime    string                    `json:"expiration_time,omitempty"`
+	DateOfExpiration  string                    `json:"date_of_expiration,omitempty"`
 	PaymentMethod     *PaymentMethodRequest     `json:"payment_method,omitempty"`
 	AutomaticPayments *AutomaticPaymentsRequest `json:"automatic_payments,omitempty"`
 	StoredCredential  *StoredCredentialRequest  `json:"stored_credential,omitempty"`
@@ -165,6 +169,7 @@ type StoredCredentialRequest struct {
 	Reason             string `json:"reason,omitempty"`
 	StorePaymentMethod bool   `json:"store_payment_method,omitempty"`
 	FirstPayment       bool   `json:"first_payment,omitempty"`
+	PrevTransactionRef string `json:"prev_transaction_ref,omitempty"`
 }
 
 // SubscriptionDataRequest represents subscription billing details for a payment transaction.
@@ -340,4 +345,25 @@ func (sr *SearchRequest) GetParams() map[string]string {
 	params["offset"] = strconv.Itoa(sr.Offset)
 
 	return params
+}
+
+// IntegrationDataRequest contains integration metadata for an order. Identifies the integrator,
+// platform, and corporation associated with the integration, as well as any sponsoring
+// marketplace owner.
+type IntegrationDataRequest struct {
+	// IntegratorID is the identifier of the certified integrator. Type: string.
+	IntegratorID string `json:"integrator_id,omitempty"`
+	// PlatformID is the platform identifier assigned by MercadoPago. Type: string.
+	PlatformID string `json:"platform_id,omitempty"`
+	// CorporationID is the corporation identifier for multi-account setups. Type: string.
+	CorporationID string `json:"corporation_id,omitempty"`
+	// Sponsor contains sponsoring marketplace owner information.
+	Sponsor *SponsorRequest `json:"sponsor,omitempty"`
+}
+
+// SponsorRequest represents the sponsoring marketplace owner associated with an order's
+// integration metadata.
+type SponsorRequest struct {
+	// ID is the MercadoPago user ID of the sponsoring marketplace owner. Type: string.
+	ID string `json:"id,omitempty"`
 }


### PR DESCRIPTION
## Summary

- **StoredCredentialRequest** → added `PrevTransactionRef string` — links each recurring charge to the original card-network authorization; required from the second charge onwards in the AP flow.
- **PaymentRequest** → added `DateOfExpiration string` (ISO 8601) — absolute payment expiry date, distinct from the relative `ExpirationTime` TTL.
- **Request (root)** → added `IntegrationData *IntegrationDataRequest` — integration metadata for marketplace and platform identification.
- **IntegrationDataRequest** (new struct) → `IntegratorID`, `PlatformID`, `CorporationID` (string) + `Sponsor *SponsorRequest`.
- **SponsorRequest** (new struct) → `ID string` — MercadoPago user ID of the sponsoring marketplace owner.

All fields use `json:"...,omitempty"` — omitted when empty, zero break changes.

## Context

Part of IXE-679: fields required for the Automatic Payments (recurring without CVV) flow in the Orders API were missing from the public SDKs. Companion PRs exist for Java, .NET, Node.js, PHP, Python and Ruby.

## Test plan

- [x] `go build ./...` — no errors
- [x] `go test ./pkg/order/...` — ok
- [ ] Integration tests (not run per policy)

Generated with [Claude Code](https://claude.com/claude-code)