### PR TITLE
fix(webhook): preserve data.id case in signature manifest

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -255,7 +255,7 @@ func parseSignatureHeader(header string) (ts string, hashes map[string]string) {
 func buildManifest(dataID, requestID, ts string) string {
 	parts := make([]string, 0, 3)
 	if dataID != "" {
-		parts = append(parts, "id:"+strings.ToLower(dataID))
+		parts = append(parts, "id:"+dataID)
 	}
 	if requestID != "" {
 		parts = append(parts, "request-id:"+requestID)

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -22,7 +22,7 @@ const (
 func computeHash(dataID, requestID, ts, secret string) string {
 	var parts []string
 	if dataID != "" {
-		parts = append(parts, "id:"+strings.ToLower(dataID))
+		parts = append(parts, "id:"+dataID)
 	}
 	if requestID != "" {
 		parts = append(parts, "request-id:"+requestID)
@@ -65,8 +65,8 @@ func TestValidateSignature_HappyPathLowercase(t *testing.T) {
 }
 
 // case 2
-func TestValidateSignature_UppercaseDataIDIsLowercased(t *testing.T) {
-	h := computeHash(dataIDLower, requestID, ts, secret)
+func TestValidateSignature_UppercaseDataIDIsPreserved(t *testing.T) {
+	h := computeHash(dataIDRaw, requestID, ts, secret)
 	if err := ValidateSignature(buildHeader(h), requestID, dataIDRaw, secret); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Problem

`ValidateSignature` was calling `strings.ToLower(dataID)` before building the HMAC manifest. MercadoPago signs webhook notifications using the original casing of `data.id`, so any notification with uppercase or mixed-case identifiers would fail validation with `SignatureMismatch`.

## Fix

Remove the `strings.ToLower` call in `buildManifest` so the value is included exactly as received.

## Testing

Verified manually with `data.id` values in uppercase (`ORDER123`), lowercase (`order123`), and mixed case (`oRdEr`) — all pass when the signature was generated with the same casing.