### PR TITLE
Fix industry field inconsistencies and add missing fields

### DIFF
--- a/pkg/order/request.go
+++ b/pkg/order/request.go
@@ -266,6 +266,7 @@ type AddressRequest struct {
 // ItemsRequest represents a line item in an order. Each item describes a product or service
 // being purchased, including its price, quantity, and descriptive metadata.
 type ItemsRequest struct {
+	ID           string `json:"id,omitempty"`
 	Title        string `json:"title,omitempty"`
 	Type         string `json:"type,omitempty"`
 	Warranty     bool   `json:"warranty,omitempty"`

--- a/pkg/payment/request.go
+++ b/pkg/payment/request.go
@@ -67,6 +67,7 @@ type AdditionalInfoRequest struct {
 type AdditionalInfoPayerRequest struct {
 	Phone            *AdditionalInfoPayerPhoneRequest   `json:"phone,omitempty"`
 	Address          *AdditionalInfoPayerAddressRequest `json:"address,omitempty"`
+	Identification   *IdentificationRequest             `json:"identification,omitempty"`
 	RegistrationDate *time.Time                         `json:"registration_date,omitempty"`
 	LastPurchase     *time.Time                         `json:"last_purchase,omitempty"`
 

--- a/pkg/preference/request.go
+++ b/pkg/preference/request.go
@@ -128,6 +128,9 @@ type PassengerRequest struct {
 
 	// IdentificationNumber is the passenger's identification document number.
 	IdentificationNumber string `json:"identification_number,omitempty"`
+
+	// Identification contains the passenger's identity document details as a nested struct.
+	Identification *IdentificationRequest `json:"identification,omitempty"`
 }
 
 // RouteRequest represents travel route details for travel-related items in the checkout preference.
@@ -196,8 +199,8 @@ type ItemRequest struct {
 	// Quantity is the number of units of this item being purchased.
 	Quantity int `json:"quantity,omitempty"`
 
-	// Warranty is a description of the item warranty.
-	Warranty string `json:"warranty,omitempty"`
+	// Warranty indicates whether the item includes a warranty.
+	Warranty *bool `json:"warranty,omitempty"`
 
 	// CategoryDescriptor provides additional categorization metadata, such as travel or event details.
 	CategoryDescriptor CategoryDescriptorRequest `json:"category_descriptor,omitempty"`
@@ -231,8 +234,8 @@ type PayerRequest struct {
 	// RegistrationDate is the date when the buyer registered in the integrator's platform.
 	RegistrationDate *time.Time `json:"registration_date,omitempty"`
 
-	// LastPurchaseDate is the date of the buyer's most recent purchase.
-	LastPurchaseDate *time.Time `json:"last_purchase_date,omitempty"`
+	// LastPurchase is the date of the buyer's most recent purchase.
+	LastPurchase *time.Time `json:"last_purchase,omitempty"`
 
 	// Identification contains the buyer's identity document details.
 	Identification *IdentificationRequest `json:"identification,omitempty"`


### PR DESCRIPTION
- preference/request.go: fix LastPurchase JSON tag from last_purchase_date to last_purchase; add Identification to PassengerRequest; fix Warranty type from string to *bool
- preference/response.go: remove stale last_purchase_date duplicate
- payment/request.go: add Identification to AdditionalInfoPayerRequest
- order/request.go: add ID field to ItemsRequest