### PR TITLE
fix: escape dynamic API path parameters

### DIFF
--- a/pkg/internal/httpclient/helper.go
+++ b/pkg/internal/httpclient/helper.go
@@ -131,10 +131,12 @@ func setHeaders(req *http.Request, cfg *config.Config, requestData RequestData) 
 
 func setPathParams(req *http.Request, params map[string]string) error {
 	pathURL := req.URL.Path
+	rawPathURL := req.URL.Path
 
 	for k, v := range params {
 		pathParam := "{" + k + "}"
 		pathURL = strings.Replace(pathURL, pathParam, v, 1)
+		rawPathURL = strings.Replace(rawPathURL, pathParam, url.PathEscape(v), 1)
 	}
 
 	matches := pathParamRegexp.FindAllString(pathURL, -1)
@@ -143,6 +145,7 @@ func setPathParams(req *http.Request, params map[string]string) error {
 	}
 
 	req.URL.Path = pathURL
+	req.URL.RawPath = rawPathURL
 	return nil
 }
 

--- a/pkg/internal/httpclient/helper_test.go
+++ b/pkg/internal/httpclient/helper_test.go
@@ -1,0 +1,21 @@
+package httpclient
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSetPathParamsEscapesPathTraversal(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://api.mercadopago.com/v1/customers/{id}", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := setPathParams(req, map[string]string{"id": "../../applications/123"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if req.URL.EscapedPath() != "/v1/customers/..%2F..%2Fapplications%2F123" {
+		t.Fatalf("unexpected path: %s", req.URL.Path)
+	}
+}


### PR DESCRIPTION
## Summary
- Escapes path parameter substitutions in the internal HTTP client.
- Uses RawPath to preserve a single encoded representation on outbound requests.
- Adds regression coverage for traversal-style path parameters.

## Validation
- `go test ./pkg/internal/httpclient`