### PR TITLE
Bump version to 1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## VERSION 1.12.1 - 2026-07-22
+- Patch release: dependency updates and bug fixes.
+
 ## VERSION 1.12.0 - 2026-06-30
 - Orders: added Checkout Pro request and response fields.
 

--- a/pkg/internal/httpclient/helper.go
+++ b/pkg/internal/httpclient/helper.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	currentSDKVersion string = "1.12.0"
+	currentSDKVersion string = "1.12.1"
 	productID         string = "CNITR48HSRV0CRPT3NI0"
 )
 


### PR DESCRIPTION
## Summary
- Bump patch version from 1.12.0 to 1.12.1

## Files changed
- `pkg/internal/httpclient/helper.go` — `currentSDKVersion` updated to 1.12.1
- `CHANGELOG.md` — new entry added for 1.12.1

## Test plan
- [ ] Verify CI passes
- [ ] Confirm version string is correct in all files