### PR TITLE
Add CREDENTIAL_ON_FILE messaging fields to Payment types

### DIFF
--- a/pkg/payment/request.go
+++ b/pkg/payment/request.go
@@ -288,10 +288,14 @@ type TransactionDataRequest struct {
 	SubscriptionSequence *SubscriptionSequenceRequest `json:"subscription_sequence,omitempty"`
 	InvoicePeriod        *InvoicePeriodRequest        `json:"invoice_period,omitempty"`
 	PaymentReference     *PaymentReferenceRequest     `json:"payment_reference,omitempty"`
+	Reference            *ReferenceRequest            `json:"reference,omitempty"`
 
-	SubscriptionID string `json:"subscription_id,omitempty"`
-	BillingDate    string `json:"billing_date,omitempty"`
-	FirstTimeUse   bool   `json:"first_time_use,omitempty"`
+	SubscriptionID       string `json:"subscription_id,omitempty"`
+	BillingDate          string `json:"billing_date,omitempty"`
+	FirstTimeUse         bool   `json:"first_time_use,omitempty"`
+	FirstTransaction     bool   `json:"first_transaction,omitempty"`
+	Storage              string `json:"storage,omitempty"`
+	TransactionInitiator string `json:"transaction_initiator,omitempty"`
 }
 
 // SubscriptionSequenceRequest tracks the position of a payment within a recurring subscription.
@@ -312,6 +316,12 @@ type InvoicePeriodRequest struct {
 // It is used within [TransactionDataRequest].
 type PaymentReferenceRequest struct {
 	ID string `json:"id,omitempty"`
+}
+
+// ReferenceRequest contains a reference identifier for credential-on-file transactions.
+// It is used within [TransactionDataRequest].
+type ReferenceRequest struct {
+	ID string `json:"id"`
 }
 
 // PaymentMethodRequest specifies the payment method type and associated data such as

--- a/pkg/payment/response.go
+++ b/pkg/payment/response.go
@@ -314,10 +314,11 @@ type ApplicationDataResponse struct {
 // TransactionDataResponse contains transaction-specific data from the point of interaction,
 // including QR codes, ticket URLs, bank information, and subscription details.
 type TransactionDataResponse struct {
-	BankInfo             BankInfoResponse             `json:"bank_info"`
-	SubscriptionSequence SubscriptionSequenceResponse `json:"subscription_sequence"`
-	InvoicePeriod        InvoicePeriodResponse        `json:"invoice_period"`
-	PaymentReference     PaymentReferenceResponse     `json:"payment_reference"`
+	BankInfo             BankInfoResponse              `json:"bank_info"`
+	SubscriptionSequence SubscriptionSequenceResponse  `json:"subscription_sequence"`
+	InvoicePeriod        InvoicePeriodResponse         `json:"invoice_period"`
+	PaymentReference     PaymentReferenceResponse      `json:"payment_reference"`
+	Reference            TransactionReferenceResponse  `json:"reference,omitempty"`
 
 	QRCode               string `json:"qr_code"`
 	QRCodeBase64         string `json:"qr_code_base64"`
@@ -328,6 +329,15 @@ type TransactionDataResponse struct {
 	BankTransferID       int    `json:"bank_transfer_id"`
 	FinancialInstitution int    `json:"financial_institution"`
 	FirstTimeUse         bool   `json:"first_time_use"`
+	FirstTransaction     bool   `json:"first_transaction,omitempty"`
+	Storage              string `json:"storage,omitempty"`
+	TransactionInitiator string `json:"transaction_initiator,omitempty"`
+}
+
+// TransactionReferenceResponse contains a reference identifier for credential-on-file transactions.
+// It is used within [TransactionDataResponse].
+type TransactionReferenceResponse struct {
+	ID string `json:"id"`
 }
 
 // BankInfoResponse contains banking details for both the payer and the collector,


### PR DESCRIPTION
## Summary

- Adds `FirstTransaction bool`, `Storage string`, `TransactionInitiator string`, and `Reference *ReferenceRequest` to `TransactionDataRequest` in `pkg/payment/request.go`
- Adds a new `ReferenceRequest` struct (with `ID string`) for credential-on-file transaction references in requests
- Adds `FirstTransaction bool`, `Storage string`, `TransactionInitiator string`, and `Reference TransactionReferenceResponse` to `TransactionDataResponse` in `pkg/payment/response.go`
- Adds a new `TransactionReferenceResponse` struct (with `ID string`) for credential-on-file transaction references in responses
- All legacy fields (`FirstTimeUse`, `PaymentReference`) are preserved for backwards compatibility

## Test plan

- [ ] Verify `go build ./pkg/payment/...` passes without errors
- [ ] Verify `go test ./pkg/...` passes
- [ ] Confirm JSON serialization of `TransactionDataRequest` with new fields produces the expected payload for a CREDENTIAL_ON_FILE payment
- [ ] Confirm JSON deserialization of a CREDENTIAL_ON_FILE API response correctly populates the new fields in `TransactionDataResponse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)