### PR TITLE
chore: bump version to 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## VERSION 1.13.0 - 2026-08-04
+- feat: SDK ergonomics — typed errors, configurable retry and auto-pagination ([#143](https://github.com/mercadopago/sdk-go/pull/143)). New typed error hierarchy with 12 specific subtypes per HTTP status code. Request config gains optional `MaxRetries`, `RetryOn`, `InitialDelayMs`, `MaxDelayMs` and `OnRetry` callback. New auto-pagination support on search endpoints.
+- feat: add missing API methods — `DisbursementRefund.List()`, `AdvancedPayment.Update()`, `CustomerCard.Update()`, `Payment.Update()` ([#141](https://github.com/mercadopago/sdk-go/pull/141))
+- feat: add CREDENTIAL_ON_FILE messaging fields to Payment types ([#137](https://github.com/mercadopago/sdk-go/pull/137)): `FirstTransaction`, `Storage`, `TransactionInitiator`, `Reference`
+- Bump `actions/checkout` to `v7.0.1` ([#140](https://github.com/mercadopago/sdk-go/pull/140))
+- Bump `actions/setup-go` to `v7.0.0` ([#136](https://github.com/mercadopago/sdk-go/pull/136))
+
 ## VERSION 1.12.1 - 2026-07-22
 - Patch release: dependency updates and bug fixes.
 

--- a/pkg/internal/httpclient/helper.go
+++ b/pkg/internal/httpclient/helper.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	currentSDKVersion string = "1.12.1"
+	currentSDKVersion string = "1.13.0"
 	productID         string = "CNITR48HSRV0CRPT3NI0"
 )
 


### PR DESCRIPTION
## Summary

- Bump version from `1.12.1` to `1.13.0`
- Update `pkg/internal/httpclient/helper.go` and `CHANGELOG.md`

## Changelog entry

- feat: SDK ergonomics — typed errors, configurable retry and auto-pagination ([#143](https://github.com/mercadopago/sdk-go/pull/143))
- feat: add missing API methods — `DisbursementRefund.List()`, `AdvancedPayment.Update()`, `CustomerCard.Update()`, `Payment.Update()` ([#141](https://github.com/mercadopago/sdk-go/pull/141))
- feat: add CREDENTIAL_ON_FILE messaging fields to Payment types ([#137](https://github.com/mercadopago/sdk-go/pull/137)): `FirstTransaction`, `Storage`, `TransactionInitiator`, `Reference`
- Bump `actions/checkout` to `v7.0.1` ([#140](https://github.com/mercadopago/sdk-go/pull/140))
- Bump `actions/setup-go` to `v7.0.0` ([#136](https://github.com/mercadopago/sdk-go/pull/136))

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files